### PR TITLE
Adding cpio and cache

### DIFF
--- a/Building.md
+++ b/Building.md
@@ -24,7 +24,8 @@ apt install -y \
 	python \
 	wget \
 	gnat \
-	cpio
+	cpio \
+	ccache
 ```
 
 On a Fedora machine:

--- a/Building.md
+++ b/Building.md
@@ -23,7 +23,8 @@ apt install -y \
 	patch \
 	python \
 	wget \
-	gnat
+	gnat \
+	cpio
 ```
 
 On a Fedora machine:


### PR DESCRIPTION
Apperently, cpio is missing on docker ubuntu.

Also, ccache is nice boost to compilation time... 